### PR TITLE
fix Edit Mode, right rotate grids

### DIFF
--- a/lib/domains/board/goal.dart
+++ b/lib/domains/board/goal.dart
@@ -44,9 +44,12 @@ class Goal {
 
   Goal get nextColor {
     if (color == null) {
-      return this;
+      return Goal(color: RobotColors.values[0], type: GoalTypes.values[0]);
     }
     final nextIndex = (color!.index + 1) % RobotColors.values.length;
+    if (nextIndex == 0) {
+      return const Goal(color: null, type: null);
+    }
     final nextColor = RobotColors.values[nextIndex];
     return Goal(color: nextColor, type: type);
   }

--- a/lib/domains/board/grid.dart
+++ b/lib/domains/board/grid.dart
@@ -4,6 +4,7 @@ import 'package:ricochet_robots/domains/board/robot.dart';
 
 abstract class Rotatable {
   Grid get rotateRight;
+  Grid copyWithCanMoveOnly(Grid grid);
 }
 
 abstract class Grid implements Rotatable {
@@ -78,6 +79,16 @@ class NormalGrid extends Grid {
       );
 
   @override
+  NormalGrid copyWithCanMoveOnly(Grid grid) {
+    return NormalGrid(
+      canMoveUp: grid.canMoveUp,
+      canMoveRight: grid.canMoveRight,
+      canMoveDown: grid.canMoveDown,
+      canMoveLeft: grid.canMoveLeft,
+    );
+  }
+
+  @override
   NormalGrid setCanMove({
     required Directions directions,
     required bool canMove,
@@ -139,6 +150,18 @@ class NormalGoalGrid extends GoalGrid {
       );
 
   @override
+  NormalGoalGrid copyWithCanMoveOnly(Grid grid) {
+    return NormalGoalGrid(
+      color: color,
+      type: type,
+      canMoveUp: grid.canMoveUp,
+      canMoveRight: grid.canMoveRight,
+      canMoveDown: grid.canMoveDown,
+      canMoveLeft: grid.canMoveLeft,
+    );
+  }
+
+  @override
   NormalGoalGrid setCanMove({
     required Directions directions,
     required bool canMove,
@@ -178,6 +201,16 @@ class WildGoalGrid extends GoalGrid {
         canMoveDown: canMoveRight,
         canMoveLeft: canMoveDown,
       );
+
+  @override
+  WildGoalGrid copyWithCanMoveOnly(Grid grid) {
+    return WildGoalGrid(
+      canMoveUp: grid.canMoveUp,
+      canMoveRight: grid.canMoveRight,
+      canMoveDown: grid.canMoveDown,
+      canMoveLeft: grid.canMoveLeft,
+    );
+  }
 
   @override
   WildGoalGrid setCanMove({

--- a/lib/domains/board/grids.dart
+++ b/lib/domains/board/grids.dart
@@ -30,12 +30,22 @@ class Grids {
       return List.generate(grids[y].length, (x) {
         final position = Position(x: x, y: y);
         if (position == a) {
-          return at(position: b);
+          return at(position: b).copyWithCanMoveOnly(at(position: a));
         }
         if (position == b) {
-          return at(position: a);
+          return at(position: a).copyWithCanMoveOnly(at(position: b));
         }
         return at(position: position);
+      });
+    });
+    return Grids(grids: newGrids);
+  }
+
+  Grids get rotateRight {
+    final newGrids = List.generate(grids.length, (y) {
+      return List.generate(grids[y].length, (x) {
+        final position = Position(x: x, y: y).rotateLeft;
+        return at(position: position).rotateRight;
       });
     });
     return Grids(grids: newGrids);

--- a/lib/domains/board/position.dart
+++ b/lib/domains/board/position.dart
@@ -50,4 +50,12 @@ class Position with _$Position {
         return copyWith(x: x - 1);
     }
   }
+
+  Position get rotateRight {
+    return Position(x: -y + 16 - 1, y: x);
+  }
+
+  Position get rotateLeft {
+    return Position(x: y, y: -x + 16 - 1);
+  }
 }

--- a/lib/domains/board/robot_positions.dart
+++ b/lib/domains/board/robot_positions.dart
@@ -85,6 +85,15 @@ class RobotPositions with _$RobotPositions {
     );
   }
 
+  RobotPositions get rotateRight {
+    return copyWith(
+      red: red.rotateRight,
+      blue: blue.rotateRight,
+      green: green.rotateRight,
+      yellow: yellow.rotateRight,
+    );
+  }
+
   Robot? getRobotIfExists({required Position position}) {
     if (position == red) {
       return Robot.red;

--- a/lib/domains/edit/edit.dart
+++ b/lib/domains/edit/edit.dart
@@ -9,6 +9,7 @@ class EditAction with _$EditAction {
   const factory EditAction({
     @Default(false) bool nextGoalColor,
     @Default(false) bool nextGoalType,
+    @Default(false) bool rotateRightGrids,
     Position? position,
     Position? topBorder,
     Position? rightBorder,
@@ -35,6 +36,12 @@ class EditFunction {
         grids: newBoard.grids.swap(prePosition, action.position!),
         robotPositions:
             newBoard.robotPositions.swap(prePosition, action.position!),
+      );
+    }
+    if (action.rotateRightGrids) {
+      newBoard = newBoard.copyWith(
+        grids: newBoard.grids.rotateRight,
+        robotPositions: newBoard.robotPositions.rotateRight,
       );
     }
     if (action.topBorder != null) {

--- a/lib/domains/game/widgets/header_widget.dart
+++ b/lib/domains/game/widgets/header_widget.dart
@@ -60,10 +60,12 @@ class HeaderWidget extends StatelessWidget {
     final type = goal.type;
     final color = goal.color;
     if (type == null || color == null) {
-      return const Icon(
-        Icons.help,
-        size: 20,
+      return EditableIcon(
+        iconData: Icons.help,
         color: Colors.deepPurple,
+        size: 20,
+        editAction: const EditAction(nextGoalColor: true),
+        currentMode: currentMode,
       );
     }
     return EditableIcon(
@@ -98,6 +100,15 @@ class HeaderWidget extends StatelessWidget {
             ],
           ),
           const Expanded(child: SizedBox.shrink()),
+          toEditMode
+              ? const SizedBox.shrink()
+              : EditableIcon(
+                  iconData: Icons.rotate_right,
+                  color: Colors.grey,
+                  size: 20,
+                  editAction: const EditAction(rotateRightGrids: true),
+                  currentMode: currentMode,
+                ),
           Text("${histories.length.toString()} moves", style: _textStyle),
           const SizedBox(width: 8.0),
           IconButton(


### PR DESCRIPTION
・grid swapした時にwallはswapしないようにしました。
これがswapすると、操作が難しいので。

・盤面全体を右回転させる機能を追加しました。

・Wild Goalを選べるようにしました。

今日の盤面を作るのに必要だった機能たちです。