### PR TITLE
Fix Link

### DIFF
--- a/lib/domains/game/widgets/header_widget.dart
+++ b/lib/domains/game/widgets/header_widget.dart
@@ -79,8 +79,13 @@ class HeaderWidget extends StatelessWidget {
 
   Future<void> _copyUrlToClipBoard() async {
     final id = BoardId.from(board: board);
+    final base = Uri.parse(Uri.base.toString().replaceFirst("#", "sharp"));
+    final created = base
+        .replace(queryParameters: {...base.queryParameters, "id": id.encoded})
+        .toString()
+        .replaceFirst("sharp", "#");
     await Clipboard.setData(
-      ClipboardData(text: '${Uri.base.toString()}?id=${id.encoded}'),
+      ClipboardData(text: created),
     );
   }
 


### PR DESCRIPTION
すでにidが入っている時に、linkを生成すると、idが二重に入ってしまっていた。

"#"がuriの中で、fragmentの判定使われているようなので置換して対応している（他の方法わからず）